### PR TITLE
fix for "Not selecting" shown |   1 | Not  |libpcrecpp0   |as   |

### DIFF
--- a/opkg-upgrade.sh
+++ b/opkg-upgrade.sh
@@ -336,7 +336,7 @@ opkg_update() {
 # get list of upgradable packages
 opkg_upgradable() {
     message_starts "Getting upgradable packages list"
-    PACKS="$($OPKGBIN list-upgradable | sort | grep -v 'marked HOLD or PREFER')"
+    PACKS="$($OPKGBIN list-upgradable | sort | grep -v -e 'marked HOLD or PREFER' -e 'Not selecting')"
     #[ $? -eq 0 ] || rt_exception $'Error when trying list upgradable packages. Permissions?\n'
     #PACKS="$(cat pkg-example.txt)" # testing
     if ! is_empty "$PACKS"; then


### PR DESCRIPTION
on some non openwrt (enigma2) systems it shows "Not selecting" as fist packet to install called "Not" .With this extra string to exclude it works 